### PR TITLE
Broken link to developer documentation

### DIFF
--- a/docs/101/running-example/index.html
+++ b/docs/101/running-example/index.html
@@ -352,7 +352,7 @@ We need to prepare the zebrafish database with `makeblastdb` for the search, but
 
 <div class="alert alert-info "> <a href="#" class="close" data-dismiss="alert">&times;</a>
                     <span class="glyphicon glyphicon-info-sign" style="font-size:22px"></span> &nbsp; Here, we explain multiples concepts in the same command. The most important component is <code>-v /Users/yperez/workplace:/data/</code>. This command creates a symbolic link
- between the <code>workplace</code> where the downloaded files are store and the <code>/data/</code> inside the container. You can <a href="/developer-manual/biocontainers-input-output/">check here</a> for more documentation.  </div>
+ between the <code>workplace</code> where the downloaded files are store and the <code>/data/</code> inside the container. You can <a href="/docs/developer-manual/biocontainers-input-output/">check here</a> for more documentation.  </div>
 
 <p>No, that you know how to run a container with all the tricks, then lets go for the final alignments:</p>
 


### PR DESCRIPTION
The text says:

```
Here, we explain multiples concepts in the same command. The most important component is <code>-v /Users/yperez/workplace:/data/</code>. This command creates a symbolic link
 between the <code>workplace</code> where the downloaded files are store and the <code>/data/</code> inside the container. You can <a href="/developer-manual/biocontainers-input-output/">check here</a> for more documentation.  </div>
```
But the link for more documentation is broken.

```<a href="/docs/developer-manual/biocontainers-input-output/">check here</a>``` for more documentation.